### PR TITLE
Added logic to set image by default when creating the annotations

### DIFF
--- a/lib/project/annotation.rb
+++ b/lib/project/annotation.rb
@@ -57,14 +57,13 @@ class MapAnnotation
       marker.snippet = self.subtitle
       marker.title = self.title
       marker.appearAnimation = KGMSMarkerAnimationPop if self.animated
+      marker.icon = self.image
       if self.image_url
         url = NSURL.URLWithString(image_url)
         SDWebImageManager.sharedManager.downloadWithURL(url, options:SDWebImageRetryFailed,
           progress:nil, completed: proc do |image, error, cached, finished|
             marker.icon = image if finished
           end)
-      else
-        marker.icon = self.image
       end
       marker.infoWindowAnchor = self.info_window_anchor if self.info_window_anchor
       marker.groundAnchor = self.ground_anchor if self.ground_anchor


### PR DESCRIPTION
@MarkVillacampa Just changed this gem to be able to set an image when creating the annotation. If there is also an image_url, the fetch of the image is also triggered and, on completion, replaced.
